### PR TITLE
[Bug 1392915] Migrate Czech glossary

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -19,6 +19,7 @@
 * [Chinese, Traditional (zh-TW)](zh-TW/README.md)
 * [Czech (cs)](cs/README.md)
    * [General Style Guide](cs/general.md)
+   * [Glossary](cs/glossary.md)
 * [Dutch (nl)](nl/README.md)
 * [Esperanto (eo)](eo/README.md)
 * [Finnish (fi)](fi/README.md)

--- a/cs/README.md
+++ b/cs/README.md
@@ -5,7 +5,7 @@
 * [Co dodržovat při lokalizaci](general.md)
 * [Jak lokalizovat nápovědu k Firefoxu](https://support.mozilla.org/cs/kb/jak-lokalizovat-napovedu-k-firefoxu)
 * [Jak přeložit rozhraní SUMO](https://support.mozilla.org/cs/kb/jak-prelozit-rozhrani-sumo)
-* [Překladatelský slovník](https://www.mozilla.cz/zapojte-se/lokalizace/prekladovy-slovnik/)
+* [Překladatelský slovník](glossary.md)
 * [Překladatelský slovník - L10N.cz](http://wiki.l10n.cz/P%C5%99ekladatelsk%C3%BD_slovn%C3%ADk)
 
 ## Kontakt

--- a/cs/glossary.md
+++ b/cs/glossary.md
@@ -166,7 +166,7 @@ Další prvky viz [[Slovník vizuálních prvků]]. |
 | Anglicky | Česky |
 | --- | --- |
 | Click | Klepnutí |
-| Double click | Dvojklepnutí |
+| Double click | Poklepání |
 | Right click | Klepnutí pravým tlačítkem |
 
 ### Obecné akce

--- a/cs/glossary.md
+++ b/cs/glossary.md
@@ -1,0 +1,266 @@
+# Překladatelský slovník
+
+Pokud překládáte aplikace z rodiny Mozilla, či některá jejich rozšíření, je nutné, aby se základní termíny překládaly stejně. Uživatelé pak nejsou mateni různými výrazy, které ve skutečnosti znamenají totéž, a překlad je konzistentní.
+
+V níže uvedených tabulkách naleznete základní výrazy, které se v aplikacích často používají, a jejich české ekvivalenty. Další výrazy obsahuje [slovník L10N.cz](http://wiki.l10n.cz/P%C5%99ekladatelsk%C3%BD_slovn%C3%ADk). Pokud máte pocit, že některý běžně používaný výraz chybí, [napište nám prosím](https://www.mozilla.cz/o-nas/#kontakt).
+
+<!-- toc -->
+
+## Části aplikací
+
+| Anglicky | Česky |
+| --- | --- |
+| Navigator | Prohlížeč |
+| Browser | Prohlížeč |
+| Mail &amp; Newsgroups | Pošta a diskusní skupiny |
+| Calendar | Kalendář |
+
+## Doplňky
+
+| Anglicky | Česky |
+| --- | --- |
+| Add-on, Addon | Doplněk |
+| Dictionary | Slovník |
+| Extension | Rozšíření |
+| Plug-in, Plugin | Zásuvný modul |
+| Search module | Vyhledávací modul |
+| Theme | Motiv vzhledu |
+
+## Prvky uživatelského rozhraní
+
+### Nástrojové lišty
+
+| Anglicky | Česky |
+| --- | --- |
+| Toolbar | Nástrojová lišta |
+| Bookmarks toolbar | Lišta záložek |
+| Composition toolbar | Lišta editoru |
+| Formatting toolbar | Lišta úprav |
+| Mail toolbar | Lišta pošty |
+| Navigation toolbar | Lišta navigace |
+
+### Ostatní lišty
+
+| Anglicky | Česky |
+| --- | --- |
+| Bar | Lišta |
+| Sidebar | Postranní lišta |
+| Site navigation bar | Lišta navigace webu |
+| Search bar | Lišta hledání |
+| Component bar | Lišta komponent |
+| Status bar | Stavový řádek |
+| Quick Filter Bar | Lišta rychlého filtru |
+
+### Prvky lišty navigace
+
+| Anglicky | Česky |
+| --- | --- |
+| Back | Zpět |
+| Forward | Vpřed |
+| Reload | Obnovit |
+| Stop | Zastavit |
+| Home | Domů |
+| Location Bar | Adresní řádek |
+| Awesome Bar | Chytrý adresní řádek |
+| Go | Přejít |
+| Search bar | Pole hledání |
+
+### Prvky lišty pošty
+
+| Anglicky | Česky |
+| --- | --- |
+| Reply | Odpovědět |
+| Reply all | Odpovědět všem (zkrácený výraz Odp. všem) |
+| Forward | Přeposlat |
+
+### Dialogy a upozornění
+
+| Anglicky | Česky |
+| --- | --- |
+| Alert | Výstraha |
+| Confirm | Potvrzení |
+| Dialog | Dialogové okno; pouze Dialog, pokud je ve spojení s názvem dialogu (př. Preferences dialog = Dialog předvoleb) |
+| Error console | Chybová konzole |
+| Notification | Oznámení |
+| Options | Možnosti |
+| Preferences | Předvolby |
+| Prompt | Výzva |
+| Settings | Nastavení |
+
+### Obecné prvky uživatelského rozhraní
+
+| Anglicky | Česky |
+| --- | --- |
+| Box | Pole |
+| Controls | Ovládací prvky |
+| Down-box list | Rozbalovací seznam |
+| Form | Formulář |
+| Groupbox | Skupina, Skupinový rám |
+| Listbox | Rozbalovací seznam |
+| Scrollbar | Posuvník |
+| Toggle button | Přepínací tlačítko |
+
+Další prvky viz [[Slovník vizuálních prvků]]. |
+
+## Nabídky
+
+| Anglicky | Česky |
+| --- | --- |
+| Context menu | Místní nabídka |
+| Main menu, Menu Bar | Hlavní nabídka |
+| Menu | Nabídka |
+| Sub-menu | Podnabídka |
+
+### Položky hlavní nabídky
+
+| Anglicky | Česky |
+| --- | --- |
+| File | Soubor |
+| Edit | Úpravy |
+| View | Zobrazit |
+| History | Historie |
+| Go | Přejít |
+| Bookmarks | Záložky |
+| Message | Zpráva |
+| Tools | Nástroje |
+| Help | Nápověda |
+
+### Položky nabídky Soubor
+
+| Anglicky | Česky |
+| --- | --- |
+| Close | Zavřít |
+| Print preview | Náhled tisku |
+| Page setup | Vzhled stránky |
+| Exit | Ukončit |
+
+### Položky nabídky Úpravy
+
+| Anglicky | Česky |
+| --- | --- |
+| Undo | Zpět |
+| Redo | Znovu |
+| Cut | Vyjmout |
+| Copy | Kopírovat |
+| Paste | Vložit |
+| Delete | Smazat |
+| Select all | Vybrat vše |
+
+### Položky nabídky Nápověda
+
+| Anglicky | Česky |
+| --- | --- |
+| About | O aplikaci/O rozšíření |
+
+### Položky místní nabídky
+
+| Anglicky | Česky |
+| --- | --- |
+| Page source | Zdrojový kód stránky |
+| Send link | Odeslat odkaz |
+
+## Akce uživatele
+
+### Akce myší
+
+| Anglicky | Česky |
+| --- | --- |
+| Click | Klepnutí |
+| Double click | Dvojklepnutí |
+| Right click | Klepnutí pravým tlačítkem |
+
+### Obecné akce
+
+| Anglicky | Česky |
+| --- | --- |
+| Apply | Použít |
+| Block | Blokovat, Zakázat |
+| Browse | Procházet |
+| Execute | Provést, Vykonat |
+| Expires | Platnost do |
+| Find | Hledat |
+| Find as you type | Hledat během psaní text |
+| Flush | Vyprázdnit |
+| Highlight | Zvýraznit (zvýraznění) |
+| Check | Zaškrtnout, Zkontrolovat (záleží na kontextu) |
+| Load | Načíst |
+| Search | Hledat |
+| Upload | Nahrát |
+| Uncheck | Odškrtnout |
+
+## Obecné výrazy
+
+| Anglicky | Česky |
+| --- | --- |
+| Advanced | Rozšířené |
+| Attribute | Atribut |
+| Default | Výchozí |
+| Character coding | Znaková sada |
+| Character set | Znaková sada |
+| Internet | internet (s malým i na začátku) |
+| Key modifier | Modifikátor klávesové zkratky |
+| Login | Přihlašovací údaje |
+| Master password | Hlavní heslo |
+| Restore | Obnovit |
+| Release notes | Poznámky k vydání |
+| Security | Zabezpečení |
+| Session | Relace |
+| Upgrade | Aktualizace |
+| User profile | Uživatelský profil |
+| Profile manager | Správce profilů |
+
+## Odborné výrazy
+
+| Anglicky | Česky |
+| --- | --- |
+| Authentication | Autentizace |
+| Bug | Chyba |
+| Build | Sestavení |
+| Cookies | (nepřekládáme) |
+| Debug | Ladit |
+| Debugger | (nepřekládáme) |
+| Decrypt | Dešifrovat |
+| Encrypt | Zašifrovat |
+| Nightly build | Noční verze |
+| Pipelining | Proudové zpracování |
+| Referer | Odkazující <abbr lang="en" title="Uniform Resource Locator">URL</abbr> |
+| RSS feed | <abbr lang="en" title="Really Simple Syndication">RSS</abbr> kanál |
+| Search engine | Vyhledávač |
+| SmartCard | (nepřekládáme) |
+| Stylesheet | Kaskádový styl |
+
+## Prohlížeč
+
+| Anglicky | Česky |
+| --- | --- |
+| Bookmarks | Záložky |
+| Frame | Rám |
+| Homepage | Domovská stránka |
+| Image/text placehold | Zástupný obrázek/text |
+| Live bookmark | Aktuální záložka |
+| Location | Umístění (když mluvíme o prvku), Adresa (pokud se jedná o URL) |
+| Location Aware Browsing | Prohlížení se znalostí polohy |
+| Private browsing | Anonymní prohlížení |
+| Tab | Panel |
+| Website | Webový server (dle kontextu lze překládat i jako webová stránka) |
+
+## E-mailový klient
+
+| Anglicky | Česky |
+| --- | --- |
+| Address book | Část aplikace na správu kontaktů se jmenuje ''Adresář''. Kontakty jsou ve složkách, které se nazývají ''Složky kontaktů'' a nejnižším prvkem je samotný ''Kontakt''. |
+| Attach | Připojit |
+| Attachment | Příloha |
+| Card/vCard | Vizitka |
+| Compact Folders | Provést údržbu složek |
+| Label | Štítek |
+| Mail (sloveso) | Poslat |
+| Mark | Označit |
+| Newsgroup | Diskusní skupina |
+| RSS feed | RSS kanál |
+| Saved search | Uložené hledání |
+| Scam | Podvodný e-mail |
+| Subscribe | Odebírat |
+| Spam | Nevyžádaná pošta |
+| Thread | Vlákno |
+| Unsubscribe | Neodebírat |

--- a/cs/glossary.md
+++ b/cs/glossary.md
@@ -2,7 +2,7 @@
 
 Pokud překládáte aplikace z rodiny Mozilla, či některá jejich rozšíření, je nutné, aby se základní termíny překládaly stejně. Uživatelé pak nejsou mateni různými výrazy, které ve skutečnosti znamenají totéž, a překlad je konzistentní.
 
-V níže uvedených tabulkách naleznete základní výrazy, které se v aplikacích často používají, a jejich české ekvivalenty. Další výrazy obsahuje [slovník L10N.cz](http://wiki.l10n.cz/P%C5%99ekladatelsk%C3%BD_slovn%C3%ADk). Pokud máte pocit, že některý běžně používaný výraz chybí, [napište nám prosím](https://www.mozilla.cz/o-nas/#kontakt).
+V níže uvedených tabulkách naleznete základní výrazy, které se v aplikacích často používají, a jejich české ekvivalenty. Další výrazy obsahuje [slovník L10N.cz](http://wiki.l10n.cz/P%C5%99ekladatelsk%C3%BD_slovn%C3%ADk) nebo online [nástroj Transvision](https://transvision.mozfr.org/?locale=cs&t2t=t2t). Pokud máte pocit, že některý běžně používaný výraz v tomto slovníku chybí, [napište nám prosím](https://www.mozilla.cz/o-nas/#kontakt).
 
 <!-- toc -->
 


### PR DESCRIPTION
Import our glossary from [wiki.l10n.cz](http://wiki.l10n.cz/Mozilla:P%C5%99ekladatelsk%C3%BD_slovn%C3%ADk).