### PR TITLE
Set up the "en" template for Firefox marketing l10n guide

### DIFF
--- a/docs/guidelines/marketing_guide_to_firefox_l10n.md
+++ b/docs/guidelines/marketing_guide_to_firefox_l10n.md
@@ -1,16 +1,16 @@
 # Firefox localization copy guide
 
-This document is intended to facilitate the creation and localization of copy, and to support optimal preparation and consistency. This is a living document and it reflects our current state. As our brand expression continues to evolve, we&#39;ll make updates to this doc.
+This document is intended to facilitate the creation and localization of copy, and to support optimal preparation and consistency. This is a living document and it reflects our current state. As our brand expression continues to evolve, we’ll make updates to this doc.
 
-**Why is this guide important for the localization of Firefox marketing copy?**
+## Why is this guide important for the localization of Firefox marketing copy?
 
-This guide is intended to help you better understand Firefox as a brand to get a better sense of how to approach translating in your language. In addition, we&#39;ll share fixed, company-specific word choices and spelling to facilitate the localization process.
+This guide is intended to help you better understand Firefox as a brand to get a better sense of how to approach translating in your language. In addition, we’ll share fixed, company-specific word choices and spelling to facilitate the localization process.
 
 Our copy should not be translated literally one to one, but should reflect our brand personality and tone and be optimized for the appropriate cultural and linguistic perspective. The emotional and figurative intention of the source text should be adapted for the target language.
 
 ## About Firefox — Who we are
 
-Firefox is more than just the browser. Firefox is _a challenger brand_ that challenges the status quo and advocates for users&#39; online rights.
+Firefox is more than just the browser. Firefox is _a challenger brand_ that challenges the status quo and advocates for users’ online rights.
 
 In everything we do, we put the rights and needs of users first. And as a tech company, we always put people before profit.
 
@@ -53,10 +53,10 @@ Conscious Choosers:
 
 | **Attribute** | **Firefox Brand Personality** |
 | --- | --- |
-| Opinionated | **Firefox acts out of conviction and takes clear positions with confidence.**  <br><br>Our products show that our motivation derives from our brand vision. Our brand ethos is at the root of everything we do. And that&#39;s what we want to communicate to our users and partners. |
-| Open | **Firefox thinks that the internet should be open, accessible and safe for everyone.**  <br><br>We strive for open conversation and collaboration. We are: Open minded. Open-hearted. Open source. A global perspective is an integral part of our brand. We speak many languages and try to take different perspectives. |
-| Kind | **Firefox anticipates needs, offering solutions and alternatives where users&#39; freedom and rights are threatened or abused.**  <br><br>We want the best for our users and the world, so we lead by example. We develop better products, we start dialogues, we work openly and with others, we educate ourselves and others, and we inform our users. In doing so, we act empathically toward all people. |
-| Radical | **Firefox questions the status quo and common practices of tech giants and struggles with confidence for a better internet.**  <br><br>Looking optimistically into the future of the internet is a radical act. Bringing users&#39; needs before our own is just as radical. We challenge the status quo because we think it&#39;s the right thing to do. |
+| Opinionated | **Firefox acts out of conviction and takes clear positions with confidence.**  <br><br>Our products show that our motivation derives from our brand vision. Our brand ethos is at the root of everything we do. And that’s what we want to communicate to our users and partners.|
+| Open | **Firefox thinks that the internet should be open, accessible and safe for everyone.**  <br><br>We strive for open conversation and collaboration. We are: Open minded. Open-hearted. Open source. A global perspective is an integral part of our brand. We speak many languages and try to take different perspectives.|
+| Kind | **Firefox anticipates needs, offering solutions and alternatives where users’ freedom and rights are threatened or abused.**  <br><br>We want the best for our users and the world, so we lead by example. We develop better products, we start dialogues, we work openly and with others, we educate ourselves and others, and we inform our users. In doing so, we act empathically toward all people.|
+| Radical | **Firefox questions the status quo and common practices of tech giants and struggles with confidence for a better internet.**  <br><br>Looking optimistically into the future of the internet is a radical act. Bringing users’ needs before our own is just as radical. We challenge the status quo because we think it’s the right thing to do.|
 
 The Firefox Brand Personality is defined by the interaction of these attributes. Depending on the context, an attribute may be more forward or less forward.
 
@@ -66,15 +66,15 @@ Our tone of voice and language choices are:
 
 | Tone | |
 | --- | --- |
-| Direct, clear, easy to understand | We want users to feel welcome, and we use words and concepts that everyone understands. |
-| Concise | We like short headlines, phrases and clear calls-to-action.  We try to avoid complicated sentence structure or sentences without added value. |
-| Authentic | Our copy — like our products — is made by humans for humans. We talk to our users as equals and use natural language. |
-| Natural | We write in active voice and use passive voice sparingly. Avoid nominal style. We prefer two short sentences to one long one. |
-| Respectful | Be respectful without sounding too formal. |
-| Humorous | Be fun without becoming too flippant or cheesy. |
-| Relevant | We meet our users where they are. They should be able to quickly grasp our content and feel a personal connection. Cultural allusions must make sense and fit the market rather than be literally translated without appropriate cultural context. |
-| Optimistic and motivating | We believe in a positive future for the internet. Although we sometimes talk about things that are not going so well, we prefer to take a positive outlook. |
-| Creative | While information and clarity come first, we like to use creative and interesting language in our copy. We never want to sound bland and boring. We try to avoid marketing stereotypes. |
+| Direct, clear, easy to understand | We want users to feel welcome, and we use words and concepts that everyone understands.|
+| Concise | We like short headlines, phrases and clear calls-to-action.  We try to avoid complicated sentence structure or sentences without added value.|
+| Authentic | Our copy — like our products — is made by humans for humans. We talk to our users as equals and use natural language.|
+| Natural | We write in active voice and use passive voice sparingly. Avoid nominal style. We prefer two short sentences to one long one.|
+| Respectful | Be respectful without sounding too formal.|
+| Humorous | Be fun without becoming too flippant or cheesy.|
+| Relevant | We meet our users where they are. They should be able to quickly grasp our content and feel a personal connection. Cultural allusions must make sense and fit the market rather than be literally translated without appropriate cultural context.|
+| Optimistic and motivating | We believe in a positive future for the internet. Although we sometimes talk about things that are not going so well, we prefer to take a positive outlook.|
+| Creative | While information and clarity come first, we like to use creative and interesting language in our copy. We never want to sound bland and boring. We try to avoid marketing stereotypes.|
 
 ## Glossary of term / Recurring terms (WORK IN PROGRESS)
 

--- a/docs/guidelines/marketing_guide_to_firefox_l10n.md
+++ b/docs/guidelines/marketing_guide_to_firefox_l10n.md
@@ -1,0 +1,164 @@
+# Firefox localization copy guide
+
+This document is intended to facilitate the creation and localization of copy, and to support optimal preparation and consistency. This is a living document and it reflects our current state. As our brand expression continues to evolve, we&#39;ll make updates to this doc.
+
+**Why is this guide important for the localization of Firefox marketing copy?**
+
+This guide is intended to help you better understand Firefox as a brand to get a better sense of how to approach translating in your language. In addition, we&#39;ll share fixed, company-specific word choices and spelling to facilitate the localization process.
+
+Our copy should not be translated literally one to one, but should reflect our brand personality and tone and be optimized for the appropriate cultural and linguistic perspective. The emotional and figurative intention of the source text should be adapted for the target language.
+
+## About Firefox — Who we are
+
+Firefox is more than just the browser. Firefox is _a challenger brand_ that challenges the status quo and advocates for users&#39; online rights.
+
+In everything we do, we put the rights and needs of users first. And as a tech company, we always put people before profit.
+
+Firefox as a _brand_ combines the Firefox ethos and the expanding range of products.
+
+(Mozilla is the not-for-profit organization behind Firefox.)
+
+**Brand promise**:
+
+Firefox fights for you
+
+**What are we fighting for**:
+
+Firefox fights for our users by creating products that give people control and agency over their online lives.
+
+**Firefox Products**:
+
+* Firefox Quantum (Desktop browser)
+* Firefox Mobile (für iOS und Android)
+* [Firefox Send](https://send.firefox.com/)
+* [Firefox Monitor](https://monitor.firefox.com/)
+* [Firefox Lockbox](https://lockbox.firefox.com/)
+* [Pocket](https://play.google.com/store/apps/)
+* [Firefox Reality](https://mixedreality.mozilla.org/firefox-reality/)(VR browser)
+
+## Personality and tonality
+
+### Who are we talking to?
+
+We describe our target audience as Conscious Choosers. This refers to people who make or want to make conscious decisions, online and offline.
+
+Conscious Choosers:
+
+* Develop preferences and make consumer choices carefully and consciously
+* Strive to reconcile their actions with their values and ideals
+* Are demanding customers
+* Often do their own research to fully understand all options
+
+### Our Brand Attributes and the Firefox Brand Personality
+
+| **Attribute** | **Firefox Brand Personality** |
+| --- | --- |
+| Opinionated | **Firefox acts out of conviction and takes clear positions with confidence.**  <br><br>Our products show that our motivation derives from our brand vision. Our brand ethos is at the root of everything we do. And that&#39;s what we want to communicate to our users and partners. |
+| Open | **Firefox thinks that the internet should be open, accessible and safe for everyone.**  <br><br>We strive for open conversation and collaboration. We are: Open minded. Open-hearted. Open source. A global perspective is an integral part of our brand. We speak many languages and try to take different perspectives. |
+| Kind | **Firefox anticipates needs, offering solutions and alternatives where users&#39; freedom and rights are threatened or abused.**  <br><br>We want the best for our users and the world, so we lead by example. We develop better products, we start dialogues, we work openly and with others, we educate ourselves and others, and we inform our users. In doing so, we act empathically toward all people. |
+| Radical | **Firefox questions the status quo and common practices of tech giants and struggles with confidence for a better internet.**  <br><br>Looking optimistically into the future of the internet is a radical act. Bringing users&#39; needs before our own is just as radical. We challenge the status quo because we think it&#39;s the right thing to do. |
+
+The Firefox Brand Personality is defined by the interaction of these attributes. Depending on the context, an attribute may be more forward or less forward.
+
+## Tone
+
+Our tone of voice and language choices are:
+
+| Tone | |
+| --- | --- |
+| Direct, clear, easy to understand | We want users to feel welcome, and we use words and concepts that everyone understands. |
+| Concise | We like short headlines, phrases and clear calls-to-action.  We try to avoid complicated sentence structure or sentences without added value. |
+| Authentic | Our copy — like our products — is made by humans for humans. We talk to our users as equals and use natural language. |
+| Natural | We write in active voice and use passive voice sparingly. Avoid nominal style. We prefer two short sentences to one long one. |
+| Respectful | Be respectful without sounding too formal. |
+| Humorous | Be fun without becoming too flippant or cheesy. |
+| Relevant | We meet our users where they are. They should be able to quickly grasp our content and feel a personal connection. Cultural allusions must make sense and fit the market rather than be literally translated without appropriate cultural context. |
+| Optimistic and motivating | We believe in a positive future for the internet. Although we sometimes talk about things that are not going so well, we prefer to take a positive outlook. |
+| Creative | While information and clarity come first, we like to use creative and interesting language in our copy. We never want to sound bland and boring. We try to avoid marketing stereotypes. |
+
+## Glossary of term / Recurring terms (WORK IN PROGRESS)
+
+In case of uncertainties, the [transvision search](https://transvision.mozfr.org/) can also be consulted. However, as the search often shows older versions of translations in the result list (often with the formal address), this tool serves as a guide.
+
+However, the following terms and spellings apply:
+
+| English | Locale equivalent |
+| --- | --- |
+| Activity Stream |  |
+| Extensions  |  |
+| Adblocker |  |
+| Auto-fillForm |   |
+| Browser Engine |   |
+| Browser history |  |
+| Clickbait |   |
+| to champion |   |
+| Console |   |
+| Context Graph |   |
+| Control Tab |  |
+| Corporate control |   |
+| Corporate Powers |   |
+| Customizable search defaults   |   |
+| data breach |   |
+| Debugger |   |
+| Decentralized Internet |   |
+| Decentralization |  |
+| Deep Learning |   |
+| Digital Citizenship |  |
+| Digital Inclusion |  |
+| Desktop Browser |  |
+| Dev Tools |  |
+| Download Firefox |  |
+| Dropdown menu |   |
+| Feature |  |
+| Firefox Privacy Policy |   |
+| Icon |   |
+| Inspector |   |
+| intelligent search suggestions |   |
+| Internet health |  |
+| Internet experience |   |
+| JavaScript-Debugger |  |
+| lean browser |   |
+| Lean Data Toolkit |  |
+| Library |   |
+| limited data |   |
+| local community |   |
+| Memory |   |
+| Mozillian |  |
+| Mozilla Developer Network |  |
+| Multi-process |  |
+| Network |  |
+| Network requests |   |
+| New tab |  |
+| Night mode |   |
+| Non-ProfitNot-for-profitMeet the technology company that puts people before profit. |  |
+| Open Source | |
+| Padding |   |
+| Performance |  |
+| performance panel |   |
+| Privacy |   |
+| Privacy Browsing | |
+| Privacy Policy |   |
+| rebuilt from the ground |   |
+| Responsive Design Mode |   |
+| Scratchpad |   |
+| seamlessly |   |
+| Search Choice |   |
+| Search Engine |   |
+| Search engine options |   |
+| Smarter Sharing |   |
+| Storage Panel |   |
+| Style Editor |   |
+| Tabs |  |
+| Third-party advertisers |   |
+| Technology |   |
+| technology devices |   |
+| Top Sites (new tab) |   |
+| Toolbar |   |
+| Trackers |  |
+| trust and privacy |   |
+| User |  |
+| Volunteer |  |
+| Web Audio |   |
+| Webcam-Cover |   |
+| Web-Innovations |   |
+| Web Literacy |   |


### PR DESCRIPTION
Refer to this doc for the conversion: https://docs.google.com/document/d/1C4CJzbX2oCIMYYXdsCoeqGTcNNS1wxoHEiK-qSRbXR4/edit#heading=h.3z254frkfmaz. Other than minor edit, I stick to the original copy.  
Also a shared image needs to be inserted after figuring out where to store the image. 