### PR TITLE
Fix "Pocket" brand name in Turkish Firefox marketing document

### DIFF
--- a/docs/tr/firefox_marketing.md
+++ b/docs/tr/firefox_marketing.md
@@ -31,7 +31,7 @@ Firefox, insanlara çevrim içi hayatlarında kontrol ve söz sahibi olma imkan�
 * Firefox Quantum (Masaüstü tarayıcı)
 * Firefox Mobile (iOS ve Android için)
 * [Firefox Monitor](https://monitor.firefox.com/)
-* [Cep](https://play.google.com/store/apps/)
+* [Pocket](https://play.google.com/store/apps/)
 * [Mozilla VPN](https://vpn.mozilla.org/)
 * [Firefox Gizli Ağ (FPN)](https://fpn.firefox.com/)
 * [Firefox Relay](https://relay.firefox.com/)


### PR DESCRIPTION
"Pocket" brand was localized into Turkish as "Cep". The translation itself is correct but since it's a brand name, it should stay as Pocket instead.