### PR TITLE
Update sumo.md - translation of Transition

### DIFF
--- a/docs/zh-CN/sumo.md
+++ b/docs/zh-CN/sumo.md
@@ -57,3 +57,4 @@
 | Rocket | Rocket | 不翻译 |
 | Thunderbird | Thunderbird | 不翻译 |
 | Webmaker | Webmaker | 不翻译 |
+| Transition | 迁移 | 投票决定 |


### PR DESCRIPTION
Transition is voted by Translators to be translated to
迁移