### PR TITLE
Fix typos

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,7 +9,7 @@
     * [Example style guide](guidelines/example_en-us.md)
     * [Marketing guide to Firefox localization](guidelines/firefox_marketing.md)
 * [Mozilla general style guide](mozilla_general/README.md)
-* [Africaans (af)](af/README.md)
+* [Afrikaans (af)](af/README.md)
 * [Arabic (ar)](ar/README.md)
     * [Marketing guide to Firefox localization](ar/firefox_marketing.md)
 * [Armenian (hy-AM)](hy-AM/README.md)

--- a/docs/af/README.md
+++ b/docs/af/README.md
@@ -1,4 +1,4 @@
-# Style Guide Africaans (af)
+# Style Guide Afrikaans (af)
 
 <!-- markdownlint-disable MD037 -->
 
@@ -466,7 +466,7 @@ There are a few important punctuation conventions that need to be observed:
 3. A non-defining adjectival clause is preceded by a comma before the relative pronoun and is terminated by a comma.
 4. A dash (en dash) between words should be preceded and followed by a single space.
 
-### omma vs. Period in Numerals
+### Comma vs. Period in Numerals
 
 English uses a period as decimal separator, Afrikaans usually uses a comma.
 


### PR DESCRIPTION
This PR fixes 2 typos of "Africaans" -> "Afrikaans" and one in the Afrikaans style guide.