### PR TITLE
Import Slovak style guide

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -84,6 +84,8 @@
 * [Scottish Gaelic (gd)](gd/README.md)
 * [Serbian (sr)](sr/README.md)
 * [Sinhala (si)](si/README.md)
+* [Slovak (sk)](sk/README.md)
+    * [Glossary](sk/glossary.md)
 * [Slovenian (sl)](sl/README.md)
 * [Spanish (es)](es/README.md)
     * [SUMO Style Guide](es/sumo.md)

--- a/docs/sk/README.md
+++ b/docs/sk/README.md
@@ -1,0 +1,58 @@
+# Style Guide Slovak (sk) / Ako správne lokalizovať
+
+## Obsah
+
+* [Terminologický slovník](glossary.md)
+
+ <!-- toc -->
+
+Skôr, ako sa pustíte do prekladu, je dobré si tieto základné pravidlá, ktorých by ste sa mali držať. Ušetríte tým prácu nielen sebe, ale hlavne nám. Tieto záväzné odporúčania vznikli na základe stále sa opakujúcich chýb.
+
+### Dodržiavanie terminológie
+
+Ak sú v slovenskej verzii programu používané výrazy ako „karty, panely, používateľ“ a pod., mali by ste túto terminológiu dodržiavať. Pomôckou môže byť aj náš [terminologický slovník](glossary.md).
+
+### Nepoužívať cudzie výrazy
+
+Veľmi častou chybou bývajú výskyty výrazov typu „menu, level“ a pod. Tieto výrazy nemajú so slovenčinou nič spoločné. Je nutné, aby sa používali slovenské ekvivalenty t.j. „ponuka, úroveň“ a pod.
+
+### Nepoužívať české výrazy
+
+Úplne najčastejšou chybou je prekladanie nie z originálu, ale z českého prekladu. V preklade sa potom často vyskytujú čechizmy a nespisovné slová prevzaté z češtiny. Nezakazujeme vám to, ale odporúčame prekladať z angličtiny a používať správne slovenské výrazy. Český preklad môže slúžiť ako pomôcka.
+
+Tu je tabuľka najčastejších chýb:
+* nápoveda – pomocník
+* storno – zrušiť
+* zložka – priečinok
+* tlačítko – tlačidlo
+* užívateľ – používateľ
+* obecné – všeobecné
+* panel (tab) – karta
+* spojenie – pripojenie
+
+atď.
+
+### Dodržiavať pravidlá slovenčiny a stavbu viet
+
+Preklad musí vždy spĺňať pravidlá slovenčiny. Mal by teda byť bez gramatických chýb a veta by mala dávať zmysel. Mnohí autori prekladajú „strojovo“ a nad svojim prekladom nepremýšľajú. Výsledkom je, že preklad je nepresný a nedáva zmysel. Ak sa jedná o výraz, ktorý v preklade nedáva zmysel, je niekedy vhodné napísať ho vlastnými slovami.
+
+### Používateľovi sa nerozkazuje!
+
+Často sa v prekladoch stretávame s výrazmi „Zobraz, Klikni, Použi, Vyber“ a pod. To je nesprávne, pretože používateľovi sa nerozkazuje. Správne má byť „Zobraziť, Použiť“, resp. „Vyberte, Kliknite na“…
+
+### Preklad je nutné otestovať
+
+Po dokončení lokalizácie nastupuje fáza testovania a hľadania chýb. Kontroluje sa správnosť zobrazenia znakov, či reťazce svojou dĺžkou nevhodne nerozširujú okno oproti originálu alebo či sa niektoré neprekrývajú. Samozrejmosťou je kontrola textu na preklepy a gramatické chyby.
+
+### Názov neprekladáme!
+
+Je množstvo rozšírení, ktoré obsahujú v lokalizačných reťazcoch aj názov samotného rozšírenia. Ten sa zobrazuje v rôznych situáciách ako hlavná ponuka, názvy rôznych okien, prípadne v popisných vetách vysvetľujúcich funkcie a činnosti daného rozšírenia. Je to názov rozšírenia, preto by nebolo správne prekladať ho. Týmto krokom by sme vlastne rozšírenie premenovali, čo by mohlo v krajnom prípade autora nahnevať a používateľa popliesť. Dávajte si na to pozor.
+
+## Niekoľko webových tipov pre prekladateľov:
+
+* [Slovník správnych a nesprávnych výrazov v slovenčine](https://web.archive.org/web/20120508235803/http://www.culture.gov.sk/slovnik/ak.html)
+* [Slovníkový portál Jazykovedného ústavu Ľ. Štúra SAV](https://slovnik.juls.savba.sk/)
+* [Jazykový korektor slovenského jazyka](http://www.forma.sk/spell.aspx)
+* [Elektronický lexikón slovenského jazyka](http://www.slex.sk/)
+* [Externé projekty - sk-spell](https://spell.linux.sk/externe-projekty)
+* [Online nástroje - sk-spell](https://spell.linux.sk/online-nastroje)

--- a/docs/sk/glossary.md
+++ b/docs/sk/glossary.md
@@ -1,0 +1,319 @@
+# Terminologický slovník
+
+## Obsahuje
+
+* Preklady anglických slov do slovenčiny, na ktorých sa dohodli [členovia slovenského lokalizačného tímu Linuxu](https://lists.linux.sk/mailman3/lists/sk-i18n.lists.linux.sk/). Bolo by dobré, keby sa uvedené preklady používali **záväzne**.
+* Ďalšie slová (zatiaľ oficiálne neschválené) zo [slovníka Marcela Telku](https://telka.sk/linux/sk-l10n/slovnik.html).
+* Ďalšie slová, takisto neoficiálne, ktoré použili pri prekladaní Mozilly Andrej Macko, Stanislav Višňovský, Radovan Bukóci a ďalší prekladatelia produktov Mozilly do slovenčiny.
+* Pre prispievateľov/lokalizátorov máme k dispozícii aj terminologické tabuľky so všetkými reťazcami použitými v programoch Firefox, Thunderbird a Sunbird. Len na vyžiadanie e-mailom.
+
+## Všeobecné pravidlá
+
+1. Príkazy a položky v ponukách a pod. sa prekladajú v neurčitku
+
+    (správne: Otvoriť súbor, nesprávne: Otvorenie súboru).
+
+    _POZNÁMKA Radovana Bukóciho: Názvy (titulky) okien by som naopak prekladal podstatným menom, napríklad „Search“ v ponuke a na tlačidle je „Hľadať“, ale v názve okna je „Hľadanie“._
+
+2. Pri oslovovaní sa používa malé začiatočné písmeno
+
+    (správne: zápis do vášho súboru, nesprávne: zápis do Vášho súboru).
+
+## Obsah
+
+### A
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| accelerator key | ? (v Mozille je to Ctrl a Alt) |     |
+| address book | adresár | NV  |
+| advanced | pokročilé | NV  |
+| anchor | kotva | NV  |
+| answering machine | odkazovač | O   |
+| anyway | aj tak | NV  |
+| apply | použiť |     |
+| as well as | ako aj, a tiež | O   |
+| attribute | atribút | NV  |
+| authentication | autenti(fi)kácia, overenie (totožnosti) | N, SS |
+| authorisation | autorizácia, oprávnenie, udelenie oprávnenia, overenie oprávnenia, právo na prístup | N   |
+| autocomplete | automatické dokončovanie | NV  |
+
+### B
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| back | dozadu | NV  |
+| naspäť | NB  |
+| behaviour | správanie (nie chovanie) |     |
+| bit, bits (binary digit) | bit, bity, bitov – označovanie: 1 bit, kbit – kilobit, kbps – kilobit/y/ov za sekundu (vzorku); výraz nepíšeme skrátene _kb_ ani inak, vždy bit, kbit, kbps (kbit/s), Mbit a pod.; bity sa VŽDY musia označovať v plnom znení, t.j. bit/bity, pretože ide o skratku na rozdiel od bajtov, ktoré sú základnou fyzikálnou veličinou |     |
+| bookmark | záložka | NV  |
+| both as … and as … | ako … aj ako … | O   |
+| browser | prehliadač / navigátor | NB/NT |
+| browsing | prehliadanie | NB/NT |
+| bug report | hlásenie o chybe, správa o chybe | NB  |
+| build | o.i. zostavenie |     |
+| byte, bytes | bajt, bajty, bajtov – označovanie: B–bajt, kB–kilobajty, MB–megabajty a pod. |     |
+
+### C
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| cache | cache, vyrovnávacia pamäť | NV, SS |
+| cancel | zrušiť | O   |
+| character coding | kódovanie znakov  <br>v Mozille: „znaková sada“, pretože to musí byť v tom istom rode ako „character set“ | NV/NB |
+| character set | znaková sada, kódovanie | NV/NB, SS |
+| check | 1\. (… box, column) označiť (zaškrtnúť radšej nie)  <br>2\. (… syntax, connection) skontrolovať | SS  |
+| check box | zaškrtávacie pole / políčko | NV/NB / SS |
+| začiarkavacie políčko | MS  |
+| chrome | (Mozilla) programový kód Mozilly ? | NB  |
+| collapse | zbaliť (strom) | NB/NV/SS |
+| Common name (CN) (v certifikáte) | Bežné meno (CN) (prípadne Všeobecné meno (CN)) | NV, i18n |
+| compact | o.i. zhustiť | NV  |
+| compile | kompilovať | I / SS |
+| compliant | vyhovujúci, kompatibilný, v súlade, spĺňa | SS / I |
+| contributors | prispievatelia | NB  |
+| control | ovládanie, riadenie | O   |
+| cookie | cookie | NV  |
+| customize | prispôsobiť | NV  |
+
+### D
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| default | 1. predvolený / pôvodný / prednastavený  <br>preddefinovaný / implicitný / štandardný  <br>2. predvoľba, pôvodné nastavenie | NV/NB |
+| delete | odstrániť (už to tam viac nebude) /  <br>vymazať, zmazať (ostane to tam, ale bude to prázdne/čisté) | NB  |
+| description | opis, popis | NB, SS |
+| dew point | rosný bod | SHMÚ |
+| directory | priečinok (v prekladoch používateľskej úrovne) | O   |
+| adresár (v prekladoch týkajúcich sa systému) | O   |
+| disable | zakázať | NV  |
+| dithering | rozklad | NT  |
+| download | stiahnuť/stiahnutie, prevziať/preberanie | NB, SS a MS |
+| draft | návrh, koncept | NV, SS |
+| drop down | rozbaliť | SS  |
+| drop down (list) | rozbaľovací zoznam | SS  |
+| drop down (menu) | rozbaľovacia ponuka | SS  |
+
+### E
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| e-mail | správa, pošta, elektronická pošta, e-mailová správa, e-mailový, poslať / odoslať (správu, (elektronickú) poštu, e-mail). | O, PSP, SS |
+| embedded | vložený, vstavaný, zabudovaný | O   |
+| enable | povoliť | NV  |
+| encrypt | (za)šifrovať | NB/I |
+| expand | rozbaliť | NV  |
+| expire | uplynúť, stratiť platnosť, skončiť, vypršať, expirovať | I / NB |
+
+### F
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| feature | súčasť / funkcia / črta | NV/NB |
+| feels like | (v meteorológii) pocitová teplota | SHMÚ |
+| find | hľadať (napr. v ponuke Edit > Find) | NT  |
+| Find as you type | Hľadanie počas písania |     |
+| floating figures | plávajúce obrázky (také, ktoré nie sú zviazané  <br>s konkrétnym miestom, ale umiestňujú sa dynamicky tak, aby stránka dobre vyzerala) | O   |
+| folder | priečinok | O   |
+| forward | dopredu | NV  |
+| frame | rámec | O   |
+| frameset | skupina rámcov | SS  |
+| free software | slobodný softvér, neplatený softvér | O, SS |
+| front-end | rozhranie | NT  |
+
+### H
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| handle | (v Mozille je to taký minigombík na hrane čiary, ktorá zvislo alebo vodorovne rozdeľuje okno na dve časti, po jeho stlačení sa jedno z tých podokien zroluje) |     |
+| hardware | hardvér | O   |
+| Help | Pomocník | O   |
+| highlight | zvýraznenie (pokiaľ ide o text) | O   |
+| home | domov | NV  |
+| homepage | domovská stránka | NV  |
+| host | hostiteľ / server | NV  |
+| however, | avšak, | NV  |
+
+### I
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| i.e. | t.j. | O   |
+| inline frame | plávajúci rámec ? | I   |
+| ISO image | ISO obraz | O   |
+
+### J
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| junk (mail) | spam, Nevyžiadané/á, nevyžiadaná správa/pošta, podľa toho, koľko máte miesta na preklad, pozri aj spam | O   |
+
+### L
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| label | popis, nápis, označenie, menovka, značka | NB / SS |
+| link | odkaz, prepojenie | NV, SS |
+| Linux Documentation Project | Dokumentačný projekt Linuxu | NT  |
+| list | zoznam | O   |
+| location | umiestnenie (súbor na disku), adresa (na webe) | NV, NB, SS |
+| log | denník, protokol, záznam, zápis, hlásenie, -a ? | NB  |
+| denník, záznam udalostí | SS  |
+
+### M
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| mailing list | rozosielací / rozposielací zoznam (oba sú správne) | NB  |
+| poštový zoznam | SS  |
+| managing | správa (niečoho) | NV  |
+| master password | hlavné heslo | NV  |
+| menu | ponuka | O   |
+| multiuser | viacpoužívateľský, mnohopoužívateľský | O   |
+| viacužívateľský, mnohoužívateľský  <br>Pozri [túto diskusiu](http://www.juls.savba.sk/~forum/viewtopic.php?id=4) | JULS |
+| My Sidebar | (v Netscape/Mozille) Bočný panel | NV  |
+
+### N
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| news | (v newsreaderi) diskusia,-e | NB  |
+| name | (pre osoby a zvieratá) meno |     |
+| (pre neživotné) názov |     |
+| newsgroup | diskusná skupina | NV  |
+| next | (v sprievodcovi) dopredu | NV  |
+| (v sprievodcov) ďalej | NB  |
+| normally | zvyčajne, obvykle | NB, O, SS |
+
+### O
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| Objective-C | (neprekladá sa – názov jazyka) | O   |
+| options | možnosti | NB, SS |
+| override | nahradiť | SS  |
+
+### P
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| pack, package | balík | O   |
+| page | strana (prvá, druhá, tretia…), stránka (internetová) | NB/NV |
+| paste | prilepiť | MS (Win98) |
+| plugin | zásuvný modul | NB/NV/SS |
+| policy | politika, pravidlá | NV/NB |
+| pop-up | vyskakovacie okno (v súčasnosti bežne používaný výraz, dohodnutý aj v tíme Mozilla.sk) |     |
+| prekrývacie okno (výraz vymyslený v roku 2003) | NB  |
+| kontextové okno (občas uvádza MS) | MS  |
+| prefer | preferovať | NV  |
+| preferences | predvoľby | NV  |
+| presented | poskytnutý, zadaný (kód PIN), predložený, uvedený, prekladať podľa kontextu | NV, SS |
+| preview | ukážka | NV  |
+| previous | predchádzajúci | NV  |
+| profile | profil | NV  |
+
+### Q
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| query | otázka / požiadavka | NV/NT |
+| Quick launch | (v Mozille) Rýchly štart | NB  |
+
+### R
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| recipient | adresát (toto je zaužívané v Mozille aj Thunderbirde) | NV  |
+| príjemca | SS  |
+| release | 1\. vydanie  <br>2\. vydať, zverejniť, uverejniť, uvoľniť | O   |
+| release notes | poznámky k vydaniu |     |
+| restore | obnoviť, obnovovať (napr. data zo zálohy, obsah okna) | O   |
+| revoke (certificate) | zrušiť (certifikát) | ZEP |
+
+### S
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| screen name | Zobrazované meno |     |
+| screenshot | snímka obrazovky | SS  |
+| search | hľadať, hľadanie | NV  |
+| search engine | vyhľadávač | NB  |
+| select | vybrať, označiť | NV/NB |
+| share | zdieľať, zdieľaný (priečinok) | O, SS |
+| shell | jadro | NT  |
+| shortcut | odkaz (na súbor) | NT, SS |
+| sidebar | bočný panel | O   |
+| since | ‚… are needed, since they …‘ v tomto význame ‚keďže‘, ‚pretože‘ | O   |
+| …, so that you can … | …, aby ste mohli … | O   |
+| software | softvér | O   |
+| spam (mail) | spam, Nevyžiadané/á, nevyžiadaná správa/pošta, podľa toho, koľko máte miesta na preklad, pozri aj junk | O   |
+| stream | prúd dát, prúd údajov | NT, SS |
+| stylesheet | súbor so štýlmi |     |
+| subject | (v e-maile) predmet | NV  |
+| system tray | (vo Windows) systémová lišta, počnúc Win XP je to Oznamovacia oblasť | NB  |
+
+### T
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| tab | karta, záložka, panel, list. V Mozille záložka = bookmark,  <br>panel = stránka v Bočnom paneli, a preto **tab = karta**. | NV/NB |
+| tag | tag, značka | NV/NB/SS |
+| thread | vlákno | NV  |
+| timeout | uplynutie lehoty. Treba však prekladať do slovenčiny s citom. Napr. transfer timeout – čas (vyhradený) na prenos uplynul. | I   |
+| token | token | SS  |
+| tool | nástroj | NT  |
+| toolbar | panel s nástrojmi | SS  |
+| tooltip | rada ?? (hodilo by sa niečo výstižnejsie) | NV  |
+| popis | SS  |
+| (bublin(k)ový) (p)opis | NB  |
+| treshold | hranica, limit, hraničná hodnota | NT  |
+| type ahead find | pozri Find as you type |     |
+
+### U
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| uncheck | zrušiť označenie | SS  |
+| zrušiť zaškrtnutie, vypnúť voľbu ? | NB  |
+| unless you use | pokiaľ nepoužívate | O   |
+| upgrade | aktualizácia, aktualizovať | NT  |
+| user | 1\. používateľ 2. užívateľ  <br>Pozri [túto diskusiu](http://www.juls.savba.sk/~forum/viewtopic.php?id=4) | O   |
+| utility | pomôcka | NT  |
+
+### V
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| vCard | vizitka. Ďalšie možnosti: pozdrav, osobná karta, navštívenka | NB  |
+| vendor | výrobca, vydavateľ | O, SS |
+
+### W
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| What’s Related | (v Mozille) Súvisiace stránky | NB  |
+| wizard | sprievodca | NV/NB |
+
+### Y
+
+| anglicky | slovensky | zdroj |
+| --- | --- | --- |
+| you may want to | mali by ste (niečo urobiť) | NB/I |
+
+## Kódy v tabuľke znamenajú zdroj:
+
+* O – Oficiálny (záväzný) preklad dohodnutý na konferencii [sk-i18n@lists.linux.sk](https://lists.linux.sk/mailman3/lists/sk-i18n.lists.linux.sk/)
+* NT – Neoficiálny preklad (Marcel Telka)
+* NV – Neoficiálny preklad (Stanislav Višňovský / Andrej Macko)
+* NB – Neoficiálny preklad (Radovan Bukóci)
+* I – Preklad dodal Ivar
+* MS – Microsoft (slovenské verzie produktov)
+* PSP – Pravidlá slovenského pravopisu
+* ZEP – Zákon o elektronickom podpise
+* SHMÚ – Slovenský hydrometeorologický ústav
+* SS – SlovakSoft
+* JULS – Jazykovedný ústav Ľudovíta Štúra SAV
+
+K neoficiálnym (a prípadne ku všetkým) prekladom sa môžete vyjadrovať v konferencii [sk-i18n@lists.linux.sk](https://lists.linux.sk/mailman3/lists/sk-i18n.lists.linux.sk/).
+
+_Slovník vznikol úpravou [Slovníka pre preklad Linuxu do slovenčiny](https://telka.sk/linux/sk-l10n/slovnik.html) od Marcela Telku._


### PR DESCRIPTION
Due to inactivity, the Mozilla.sk website will be mostly redirected to Mozilla.org websites, which contain up to date information. The Mozilla.sk website however also hosts the localization style guide and glossary. I am importing both here, so they have a permanent place where they can live.

Original source:
- https://www.mozilla.sk/ako-spravne-lokalizovat/
- https://www.mozilla.sk/ako-spravne-lokalizovat/slovnik/